### PR TITLE
5001-fix-user-login

### DIFF
--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -25,7 +25,7 @@ export default function Login() {
             setLoading(true)
             // Call signup function and pass in email and password
             await login(emailRef.current.value, passwordRef.current.value)
-            navigate("/") // Go back to Dashboard after user logged in
+            navigate("/dashboard") // Go back to Dashboard after user logged in
         } catch {
             setError("Failed to sign in")
         }


### PR DESCRIPTION
**Issue:** The app does not transfer users to the dashboard after they successfully logged in.

**Problem identified:** path name “/“ is only for HomePage (the first page users will see).

**Solution:** Changed path name to “/dashboard“ in the handleSubmit function under the Login component.

**Test:**

1. Run the app with "npm start"
2. Try to login with an existing user
3. Check if the account can access to dashboard after logging in